### PR TITLE
#349: Composer 2.0 compatibility for Pantheon upstream repo.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "composer/installers": "^1.8",
+        "composer/installers": "^1.9",
         "internal/upstream-configuration": "*"
     },
     "conflict": {

--- a/upstream/composer.json
+++ b/upstream/composer.json
@@ -11,14 +11,14 @@
     "require": {
         "php": ">=7.1",
         "az-digital/az_quickstart": "~2",
-        "cweagans/composer-patches": "^1.0",
+        "cweagans/composer-patches": "^1.7",
         "drupal/core-composer-scaffold": "^9",
         "drupal/core-recommended": "^9",
         "drupal/pantheon_advanced_page_cache": "1.1",
         "drupal/redis": "1.4",
         "drush/drush": "^10",
         "pantheon-systems/drupal-integrations": "^8",
-        "zaporylie/composer-drupal-optimizations": "^1.1"
+        "zaporylie/composer-drupal-optimizations": "^1.2"
     },
     "extra": {
         "patches": {


### PR DESCRIPTION
This _should_ prepare our (composer-integrated) Pantheon upstream repo for Composer 2.0.