### PR TITLE
Fixes #6 Third Party Libraries Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,10 @@
             "url": "https://packages.drupal.org/8"
         },
         {
+            "type": "composer",
+            "url": "https://asset-packagist.org"
+        },
+        {
             "type": "path",
             "url": "upstream"
         }
@@ -34,7 +38,11 @@
         "enable-patching": true,
         "installer-paths": {
             "web/core": ["type:drupal-core"],
-            "web/libraries/{$name}": ["type:drupal-library"],
+            "web/libraries/{$name}": [
+                "type:bower-asset",
+                "type:drupal-library",
+                "type:npm-asset"
+            ],
             "web/modules/contrib/{$name}": ["type:drupal-module"],
             "web/profiles/contrib/{$name}": ["type:drupal-profile"],
             "web/themes/contrib/{$name}": ["type:drupal-theme"],
@@ -44,6 +52,10 @@
             "drush/Commands/contrib/{$name}": ["type:drupal-drush"],
             "web/private/scripts/quicksilver/{$name}/": ["type:quicksilver-script"]
         },
+        "installer-types": [
+            "bower-asset",
+            "npm-asset"
+        ],
         "patchLevel": {
             "drupal/core": "-p2"
         },

--- a/upstream/composer.json
+++ b/upstream/composer.json
@@ -18,6 +18,7 @@
         "drupal/pantheon_advanced_page_cache": "1.2",
         "drupal/redis": "1.5",
         "drush/drush": "^10",
+        "oomphinc/composer-installers-extender": "2.0.0",
         "pantheon-systems/drupal-integrations": "^9",
         "zaporylie/composer-drupal-optimizations": "^1.2"
     }


### PR DESCRIPTION
This pull request adds the asset packagist settings to this repository. The reference to `oomphinc/composer-installers-extender` has been placed in the `internal/upstream-configuration` to follow the precedent of how this upstream handles its other dependencies.