### PR TITLE
Update Quickstart to 2.0.0-beta4.

### DIFF
--- a/upstream/composer.json
+++ b/upstream/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=7.3",
-        "az-digital/az_quickstart": "2.0.0-beta3",
+        "az-digital/az_quickstart": "2.0.0-beta4",
         "composer/installers": "^1.9",
         "cweagans/composer-patches": "^1.7",
         "drupal/core-composer-scaffold": "^9",


### PR DESCRIPTION
Upstream update for Quickstart beta4 release (which includes ctools security update).