### PR TITLE
Update Quickstart to 2.0.0-beta5.

### DIFF
--- a/upstream/composer.json
+++ b/upstream/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=7.3",
-        "az-digital/az_quickstart": "2.0.0-beta4",
+        "az-digital/az_quickstart": "2.0.0-beta5",
         "composer/installers": "^1.9",
         "cweagans/composer-patches": "^1.7",
         "drupal/core-composer-scaffold": "^9",


### PR DESCRIPTION
Update Pantheon upstream with latest release:
https://github.com/az-digital/az_quickstart/releases/tag/2.0.0-beta5