### PR TITLE
Update Quickstart to 2.0.0-beta6 (contains moderately critical core security update) (az-digital/az_quickstart#803).

### DIFF
--- a/upstream/composer.json
+++ b/upstream/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=7.3",
-        "az-digital/az_quickstart": "2.0.0-beta5",
+        "az-digital/az_quickstart": "2.0.0-beta6",
         "composer/installers": "^1.9",
         "cweagans/composer-patches": "^1.7",
         "drupal/core-composer-scaffold": "^9",


### PR DESCRIPTION
The Drupal core security release and the corresponding Quickstart release haven't been published yet but once they are, this should be what is needed to update the Pantheon upstream.