### PR TITLE
Closes #32: Fixed protected_web_paths setting in pantheon.upstream.yml.

### DIFF
--- a/pantheon.upstream.yml
+++ b/pantheon.upstream.yml
@@ -6,6 +6,6 @@ database:
 drush_version: 10
 build_step: true
 protected_web_paths:
-  - /private
+  - /private/
   - /sites/default/files/private/
   - /sites/default/files/config/


### PR DESCRIPTION
Our best guess as to what's preventing new sites from being created with our upstream at the moment...