### PR TITLE
Create settings.upstream.php and include it by default in settings.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ terminus -y -n drush my-site.dev -- \
 _(Replace `my-site` with actual Pantheon site name and modify account name, emails, and site name as desired)_
 
 ## Upstream Settings (settings.upstream.php)
-This file (settings.upstream.php) is included to add upstream-wide configuration to all sites using the upstream. It is strongly suggested that you not delete or modify this file as it may cause reliability issues with your site. If site-specific configuration is needed, please use settings.php.
+This file (`settings.upstream.php`) is included to add upstream-wide configuration to all sites using the upstream. It is strongly suggested that you not delete or modify this file as it may cause reliability issues with your site. If site-specific configuration is needed, please use `settings.php`.

--- a/README.md
+++ b/README.md
@@ -24,3 +24,6 @@ terminus -y -n drush my-site.dev -- \
   --verbose
 ```
 _(Replace `my-site` with actual Pantheon site name and modify account name, emails, and site name as desired)_
+
+## Upstream Settings (settings.upstream.php)
+This file (settings.upstream.php) is included to add upstream-wide configuration to all sites using the upstream. It is strongly suggested that you not delete or modify this file as it may cause reliability issues with your site. If site-specific configuration is needed, please use settings.php.

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -17,12 +17,12 @@ $settings['container_yamls'][] = __DIR__ . '/services.yml';
 include __DIR__ . "/settings.pantheon.php";
 
 /**
- * If there is an upstream settings file, then include it
+ * Include the upstream-specific settings file.
+ *
+ * Loads settings from the upstream-provided settings file. Removing this line
+ * is discouraged.
  */
-$upstream_settings = __DIR__ . "/settings.upstream.php";
-if (file_exists($upstream_settings)) {
-  include $upstream_settings;
-}
+include __DIR__ . "/settings.upstream.php";
 
 /**
  * Skipping permissions hardening will make scaffolding

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -17,6 +17,14 @@ $settings['container_yamls'][] = __DIR__ . '/services.yml';
 include __DIR__ . "/settings.pantheon.php";
 
 /**
+ * If there is an upstream settings file, then include it
+ */
+$upstream_settings = __DIR__ . "/settings.upstream.php";
+if (file_exists($upstream_settings)) {
+  include $upstream_settings;
+}
+
+/**
  * Skipping permissions hardening will make scaffolding
  * work better, but will also raise a warning when you
  * install Drupal.

--- a/web/sites/default/settings.upstream.php
+++ b/web/sites/default/settings.upstream.php
@@ -1,15 +1,18 @@
 <?php
 
-$migration_config = json_decode(file_get_contents('sites/default/files/private/migration_config.json'), TRUE);
-if (isset($migration_config)) {
-  $databases['migrate']['default'] = [
-    'database' => $migration_config['mysql_database'],
-    'password' => $migration_config['mysql_password'],
-    'host' => $migration_config['mysql_host'],
-    'port' => $migration_config['mysql_port'],
-    'username' => $migration_config['mysql_username'],
-    'driver' => 'mysql',
-    'prefix' => '',
-    'collation' => 'utf8mb4_general_ci',
-  ];
+const MIGRATION_DB_CONFIG_FILE_PATH = 'sites/default/files/private/migration_config.json';
+if (file_exists(MIGRATION_DB_CONFIG_FILE_PATH)) {
+  $migration_config = json_decode(file_get_contents(MIGRATION_DB_CONFIG_FILE_PATH), TRUE);
+  if (isset($migration_config)) {
+    $databases['migrate']['default'] = [
+      'database' => $migration_config['mysql_database'],
+      'password' => $migration_config['mysql_password'],
+      'host' => $migration_config['mysql_host'],
+      'port' => $migration_config['mysql_port'],
+      'username' => $migration_config['mysql_username'],
+      'driver' => 'mysql',
+      'prefix' => '',
+      'collation' => 'utf8mb4_general_ci',
+    ];
+  }
 }

--- a/web/sites/default/settings.upstream.php
+++ b/web/sites/default/settings.upstream.php
@@ -1,5 +1,18 @@
 <?php
 
+/**
+ * @file
+ * Upstream configuration file for AZ QuickStart sites.
+ *
+ * IMPORTANT:
+ * Do not modify this file.  This file is maintained by the AZ QuickStart
+ * upstream maintainers.
+ *
+ * Site-specific modifications belong in settings.php, not this file. This file
+ * may change in future releases and modifications would cause conflicts when
+ * attempting to apply upstream updates.
+ */
+
 const MIGRATION_DB_CONFIG_FILE_PATH = 'sites/default/files/private/migration_config.json';
 if (file_exists(MIGRATION_DB_CONFIG_FILE_PATH)) {
   $migration_config = json_decode(file_get_contents(MIGRATION_DB_CONFIG_FILE_PATH), TRUE);

--- a/web/sites/default/settings.upstream.php
+++ b/web/sites/default/settings.upstream.php
@@ -1,0 +1,15 @@
+<?php
+
+$migration_config = json_decode(file_get_contents('sites/default/files/private/migration_config.json'), TRUE);
+if (isset($migration_config)) {
+  $databases['migrate']['default'] = [
+    'database' => $migration_config['mysql_database'],
+    'password' => $migration_config['mysql_password'],
+    'host' => $migration_config['mysql_host'],
+    'port' => $migration_config['mysql_port'],
+    'username' => $migration_config['mysql_username'],
+    'driver' => 'mysql',
+    'prefix' => '',
+    'collation' => 'utf8mb4_general_ci',
+  ];
+}

--- a/web/sites/default/settings.upstream.php
+++ b/web/sites/default/settings.upstream.php
@@ -13,6 +13,11 @@
  * attempting to apply upstream updates.
  */
 
+
+/**
+ * Allow loading config for the 'migrate' database from
+ * sites/default/files/private/migration_config.json
+ */
 const MIGRATION_DB_CONFIG_FILE_PATH = 'sites/default/files/private/migration_config.json';
 if (file_exists(MIGRATION_DB_CONFIG_FILE_PATH)) {
   $migration_config = json_decode(file_get_contents(MIGRATION_DB_CONFIG_FILE_PATH), TRUE);

--- a/web/sites/default/settings.upstream.php
+++ b/web/sites/default/settings.upstream.php
@@ -13,7 +13,6 @@
  * attempting to apply upstream updates.
  */
 
-
 /**
  * Allow loading config for the 'migrate' database from
  * sites/default/files/private/migration_config.json


### PR DESCRIPTION
This PR introduces an upstream settings file and includes it by default in `settings.php`.

The initial content of settings.upstream.php add the ability to place a `migration_config.json` file in `sites/default/files/private` to make it easier to add database config for migrations.