### PR TITLE
Closes #56: Allow required plugins to run on composer 2.2.0+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,8 @@
         "allow-plugins": {
             "composer/installers": true,
             "cweagans/composer-patches": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "drupal/console-extend-plugin": true,
             "drupal/core-composer-scaffold": true,
             "oomphinc/composer-installers-extender": true,
             "zaporylie/composer-drupal-optimizations": true

--- a/composer.json
+++ b/composer.json
@@ -35,8 +35,6 @@
         "allow-plugins": {
             "composer/installers": true,
             "cweagans/composer-patches": true,
-            "dealerdirect/phpcodesniffer-composer-installer": true,
-            "drupal/console-extend-plugin": true,
             "drupal/core-composer-scaffold": true,
             "oomphinc/composer-installers-extender": true,
             "zaporylie/composer-drupal-optimizations": true

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
             "composer/installers": true,
             "cweagans/composer-patches": true,
             "drupal/core-composer-scaffold": true,
+            "oomphinc/composer-installers-extender": true,
             "zaporylie/composer-drupal-optimizations": true
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,12 @@
         "sort-packages": true,
         "platform": {
             "php": "7.4"
+        },
+        "allow-plugins": {
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "drupal/core-composer-scaffold": true,
+            "zaporylie/composer-drupal-optimizations": true
         }
     },
     "extra": {


### PR DESCRIPTION
I was building with composer version 2.2.0 and I was stopped and asked to allow each plugin to run.
This PR  will allow those plugins to run without asking for permission.

We should also consider a similar PR on az-quickstart-scaffolding for CI workflows that use composer 2.2.0