### PR TITLE
az-digital/az_quickstart#1501: Add Pantheon environment-specific config for environment_indicator module.

### DIFF
--- a/web/sites/default/settings.upstream.php
+++ b/web/sites/default/settings.upstream.php
@@ -85,4 +85,45 @@ if (defined('PANTHEON_ENVIRONMENT')) {
     $config['system.performance']['js']['preprocess'] = 0;
   }
 
+  /*
+   * Environment Indicator module settings.
+   * see: https://pantheon.io/docs/environment-indicator
+   */
+  // Pantheon Env Specific Config
+  if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
+    switch ($_ENV['PANTHEON_ENVIRONMENT']) {
+      case 'lando':
+        // Localdev or Lando environments.
+        $config['environment_indicator.indicator']['name'] = 'Local Dev';
+        $config['environment_indicator.indicator']['bg_color'] = '#990055';
+        $config['environment_indicator.indicator']['fg_color'] = '#ffffff';
+        break;
+      case 'dev':
+        $config['environment_indicator.indicator']['name'] = 'Dev';
+        $config['environment_indicator.indicator']['bg_color'] = '#4a634e';
+        $config['environment_indicator.indicator']['fg_color'] = '#ffffff';
+        break;
+      case 'test':
+        $config['environment_indicator.indicator']['name'] = 'Test';
+        $config['environment_indicator.indicator']['bg_color'] = '#a95c42';
+        $config['environment_indicator.indicator']['fg_color'] = '#ffffff';
+        break;
+      case 'live':
+        $config['environment_indicator.indicator']['name'] = 'LIVE';
+        $config['environment_indicator.indicator']['bg_color'] = '#0f0f0f';
+        $config['environment_indicator.indicator']['fg_color'] = '#dddddd';
+        break;
+      default:
+        // Multidev catchall.
+        $config['environment_indicator.indicator']['name'] = 'Multidev';
+        $config['environment_indicator.indicator']['bg_color'] = '#e7131a';
+        $config['environment_indicator.indicator']['fg_color'] = '#000000';
+        break;
+    }
+  }
+}
+else {
+  $config['environment_indicator.indicator']['name'] = 'Local';
+  $config['environment_indicator.indicator']['bg_color'] = '#707070';
+  $config['environment_indicator.indicator']['fg_color'] = '#ffffff';
 }

--- a/web/sites/default/settings.upstream.php
+++ b/web/sites/default/settings.upstream.php
@@ -85,7 +85,7 @@ if (defined('PANTHEON_ENVIRONMENT')) {
     $config['system.performance']['js']['preprocess'] = 0;
   }
 
-  /*
+  /**
    * Environment Indicator module settings.
    * see: https://pantheon.io/docs/environment-indicator
    */

--- a/web/sites/default/settings.upstream.php
+++ b/web/sites/default/settings.upstream.php
@@ -94,30 +94,30 @@ if (defined('PANTHEON_ENVIRONMENT')) {
     switch ($_ENV['PANTHEON_ENVIRONMENT']) {
       case 'lando':
         // Localdev or Lando environments.
-        $config['environment_indicator.indicator']['name'] = 'Local Dev';
+        $config['environment_indicator.indicator']['name'] = 'Local Dev (Lando)';
         $config['environment_indicator.indicator']['bg_color'] = '#990055';
         $config['environment_indicator.indicator']['fg_color'] = '#ffffff';
         break;
       case 'dev':
-        $config['environment_indicator.indicator']['name'] = 'Dev';
+        $config['environment_indicator.indicator']['name'] = 'Dev (Pantheon)';
         $config['environment_indicator.indicator']['bg_color'] = '#4a634e';
         $config['environment_indicator.indicator']['fg_color'] = '#ffffff';
         break;
       case 'test':
-        $config['environment_indicator.indicator']['name'] = 'Test';
+        $config['environment_indicator.indicator']['name'] = 'Test (Pantheon)';
         $config['environment_indicator.indicator']['bg_color'] = '#a95c42';
         $config['environment_indicator.indicator']['fg_color'] = '#ffffff';
         break;
       case 'live':
-        $config['environment_indicator.indicator']['name'] = 'LIVE';
+        $config['environment_indicator.indicator']['name'] = 'LIVE (Pantheon)';
         $config['environment_indicator.indicator']['bg_color'] = '#0f0f0f';
         $config['environment_indicator.indicator']['fg_color'] = '#dddddd';
         break;
       default:
         // Multidev catchall.
-        $config['environment_indicator.indicator']['name'] = 'Multidev';
-        $config['environment_indicator.indicator']['bg_color'] = '#e7131a';
-        $config['environment_indicator.indicator']['fg_color'] = '#000000';
+        $config['environment_indicator.indicator']['name'] = $_ENV['PANTHEON_ENVIRONMENT'] . ' (Pantheon)';
+        $config['environment_indicator.indicator']['bg_color'] = '#1e5288';
+        $config['environment_indicator.indicator']['fg_color'] = '#ffffff';
         break;
     }
   }


### PR DESCRIPTION
See az-digital/az_quickstart#1501

- Adds Pantheon environment-specific config for environment_indicator module

The timing for merging this PR will need to be coordinated with merging a PR that updates Quickstart to a release version containing the corresponding changes to Quickstart itself.