### PR TITLE
Update Pantheon Advanced Page Cache module to 2.1.2

### DIFF
--- a/upstream/composer.json
+++ b/upstream/composer.json
@@ -15,7 +15,7 @@
         "cweagans/composer-patches": "^1.7",
         "drupal/core-composer-scaffold": "^9",
         "drupal/core-recommended": "^9",
-        "drupal/pantheon_advanced_page_cache": "2.0.0",
+        "drupal/pantheon_advanced_page_cache": "2.1.1",
         "drupal/redis": "1.5",
         "drush/drush": "^11",
         "oomphinc/composer-installers-extender": "2.0.0",

--- a/upstream/composer.json
+++ b/upstream/composer.json
@@ -15,7 +15,7 @@
         "cweagans/composer-patches": "^1.7",
         "drupal/core-composer-scaffold": "^9",
         "drupal/core-recommended": "^9",
-        "drupal/pantheon_advanced_page_cache": "2.1.1",
+        "drupal/pantheon_advanced_page_cache": "2.1.2",
         "drupal/redis": "1.5",
         "drush/drush": "^11",
         "oomphinc/composer-installers-extender": "2.0.0",

--- a/upstream/composer.json
+++ b/upstream/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=7.3",
-        "az-digital/az_quickstart": "2.3.6",
+        "az-digital/az_quickstart": "2.3.7",
         "composer/installers": "^1.9",
         "cweagans/composer-patches": "^1.7",
         "drupal/core-composer-scaffold": "^9",

--- a/upstream/composer.json
+++ b/upstream/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=7.3",
-        "az-digital/az_quickstart": "2.3.5",
+        "az-digital/az_quickstart": "2.3.6",
         "composer/installers": "^1.9",
         "cweagans/composer-patches": "^1.7",
         "drupal/core-composer-scaffold": "^9",

--- a/upstream/composer.json
+++ b/upstream/composer.json
@@ -15,7 +15,7 @@
         "cweagans/composer-patches": "^1.7",
         "drupal/core-composer-scaffold": "^9",
         "drupal/core-recommended": "^9",
-        "drupal/pantheon_advanced_page_cache": "1.2",
+        "drupal/pantheon_advanced_page_cache": "2.0.0",
         "drupal/redis": "1.5",
         "drush/drush": "^11",
         "oomphinc/composer-installers-extender": "2.0.0",


### PR DESCRIPTION
https://www.drupal.org/project/pantheon_advanced_page_cache/releases/2.0.0
https://www.drupal.org/project/pantheon_advanced_page_cache/releases/2.1.0
https://www.drupal.org/project/pantheon_advanced_page_cache/releases/2.1.1
https://www.drupal.org/project/pantheon_advanced_page_cache/releases/2.1.2

https://github.com/pantheon-systems/pantheon_advanced_page_cache/releases