### PR TITLE
Closes #26: Use az-digital-bot token for Quickstart update PRs (GitHub-only fix, does not affect Pantheon sites).

### DIFF
--- a/.github/workflows/az_quickstart_release.yml
+++ b/.github/workflows/az_quickstart_release.yml
@@ -2,8 +2,6 @@ name: Create PR for new Arizona Quickstart Release
 on:
   repository_dispatch:
     types: az_quickstart_release
-env:
-  GITHUB_TOKEN: ${{ secrets.REPO_DISPATCH_TOKEN }}
 
 jobs:
   release:
@@ -24,5 +22,5 @@ jobs:
           git add upstream/composer.json
           git commit -m 'Update Arizona Quickstart to ${{ github.event.client_payload.version }}'
           git push --set-upstream origin 'az-quickstart-${{ github.event.client_payload.version }}'
-          echo "${{ GITHUB_TOKEN }}" | gh auth login --with-token
+          echo "${{ secrets.REPO_DISPATCH_TOKEN }}" | gh auth login --with-token
           gh pr create --title 'Update Arizona Quickstart to ${{ github.event.client_payload.version }}' --body ''

--- a/.github/workflows/az_quickstart_release.yml
+++ b/.github/workflows/az_quickstart_release.yml
@@ -23,4 +23,4 @@ jobs:
           git commit -m 'Update Arizona Quickstart to ${{ github.event.client_payload.version }}'
           git push --set-upstream origin 'az-quickstart-${{ github.event.client_payload.version }}'
           echo "${{ secrets.REPO_DISPATCH_TOKEN }}" | gh auth login --with-token
-          gh pr create --title 'Update Arizona Quickstart to ${{ github.event.client_payload.version }}' --body ''
+          gh pr create --title 'Update Arizona Quickstart to ${{ github.event.client_payload.version }}' --body 'Release Notes: https://github.com/az-digital/az_quickstart/releases/tag/${{ github.event.client_payload.version }}'

--- a/.github/workflows/az_quickstart_release.yml
+++ b/.github/workflows/az_quickstart_release.yml
@@ -2,6 +2,8 @@ name: Create PR for new Arizona Quickstart Release
 on:
   repository_dispatch:
     types: az_quickstart_release
+env:
+  GITHUB_TOKEN: ${{ secrets.REPO_DISPATCH_TOKEN }}
 
 jobs:
   release:
@@ -22,5 +24,5 @@ jobs:
           git add upstream/composer.json
           git commit -m 'Update Arizona Quickstart to ${{ github.event.client_payload.version }}'
           git push --set-upstream origin 'az-quickstart-${{ github.event.client_payload.version }}'
-          echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
+          echo "${{ GITHUB_TOKEN }}" | gh auth login --with-token
           gh pr create --title 'Update Arizona Quickstart to ${{ github.event.client_payload.version }}' --body ''


### PR DESCRIPTION
Added a personal token associated with the az-digital-bot to work around a limitation that is causing GH Actions to not be triggered on PRs.