### PR TITLE
Closes #137: Change default PHP version to 8.0.

### DIFF
--- a/pantheon.upstream.yml
+++ b/pantheon.upstream.yml
@@ -4,7 +4,7 @@ web_docroot: true
 # values. Overridding this setting with either "full" or "full+subdomains" in
 # the site-specific pantheon.yml file is recommended prior to site go-live.
 enforce_https: transitional
-php_version: 7.4
+php_version: 8.0
 database:
   version: 10.4
 build_step: true


### PR DESCRIPTION
PHP 7.4 is end of life after today (2022-11-28) https://www.php.net/eol.php.

We should use PHP version 8.0 by default for Quickstart sites on the Pantheon upstream.