### PR TITLE
Fix upstream Quickstart release automation GitHub workflow.

### DIFF
--- a/.github/workflows/az_quickstart_release.yml
+++ b/.github/workflows/az_quickstart_release.yml
@@ -6,12 +6,13 @@ on:
 jobs:
   release:
     name: Create PR
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.REPO_DISPATCH_TOKEN }}
       - name: Create new branch and PR
         run: |
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"

--- a/.github/workflows/az_quickstart_release.yml
+++ b/.github/workflows/az_quickstart_release.yml
@@ -11,8 +11,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.REPO_DISPATCH_TOKEN }}
       - name: Create new branch and PR
         run: |
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"


### PR DESCRIPTION

```
GitHub Actions has encountered an internal error when running your job.

Create PR for new Arizona Quickstart Release: .github#L1
The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04(ubuntu-latest), or ubuntu-22.04 instead. For more details see https://github.com/actions/virtual-environments/issues/6002
```
https://github.com/az-digital/az-quickstart-pantheon/actions/runs/4602337049/jobs/8131178864
