### PR TITLE
Setting PHP version to 8.1

### DIFF
--- a/pantheon.upstream.yml
+++ b/pantheon.upstream.yml
@@ -4,7 +4,7 @@ web_docroot: true
 # values. Overriding this setting with either "full" or "full+subdomains" in
 # the site-specific pantheon.yml file is recommended prior to site go-live.
 enforce_https: transitional
-php_version: 8.0
+php_version: 8.1
 database:
   version: 10.4
 build_step: true

--- a/upstream/composer.json
+++ b/upstream/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": ">=7.4",
+        "php": ">=8.1",
         "az-digital/az_quickstart": "2.6.4",
         "composer/installers": "^1.9",
         "cweagans/composer-patches": "^1.7",


### PR DESCRIPTION
Changing PHP version to 8.1 for when we upgrade to Drupal 10 

Related to #163 