### PR TITLE
Closes #185 & Closes #181 Update example Quicksilver scripts in light of new commands/options.

### DIFF
--- a/settings-examples/pantheon.example.yml
+++ b/settings-examples/pantheon.example.yml
@@ -18,9 +18,17 @@ workflows:
       - type: webphp
         description: Run Config Distro Update with Drush
         script: private/scripts/drush_config_distro_update.php
+      # Sync permissions after running Config Distro Update.
+      - type: webphp
+        description: Sync Permissions with Drush
+        script: private/scripts/drush_az_quickstart_sync_permissions.php
   sync_code:
     after:
       # Run Config Distro update when pushing/syncing code into dev/multidev.
       - type: webphp
         description: Run Config Distro Update with Drush
         script: private/scripts/drush_config_distro_update.php
+      # Sync permissions after running Config Distro Update.
+      - type: webphp
+        description: Sync Permissions with Drush
+        script: private/scripts/drush_az_quickstart_sync_permissions.php

--- a/web/private/scripts/drush_az_quickstart_sync_permissions.php
+++ b/web/private/scripts/drush_az_quickstart_sync_permissions.php
@@ -1,0 +1,6 @@
+<?php
+
+// Ensure new permissions are synced.
+echo "Syncing permissions...\n";
+passthru('drush -n -y az-core-config-add-permissions');
+echo "Permissions sync complete.\n";

--- a/web/private/scripts/drush_config_distro_update.php
+++ b/web/private/scripts/drush_config_distro_update.php
@@ -5,10 +5,6 @@ echo "Running Config Distro update...\n";
 passthru('drush -n -y config-distro-update --update-mode=1');
 echo "Config Distro update complete.\n";
 
-echo "Syncing permissions...\n";
-passthru('drush -n -y az-core-config-add-permissions');
-echo "Permissions sync complete.\n";
-
 // Rebuild the cache.
 echo "Clearing cache.\n";
 passthru('drush cr');

--- a/web/private/scripts/drush_config_distro_update.php
+++ b/web/private/scripts/drush_config_distro_update.php
@@ -7,7 +7,7 @@ echo "Config Distro update complete.\n";
 
 echo "Syncing permissions...\n";
 passthru('drush -n -y az-core-config-add-permissions');
-echo "Config Distro update complete.\n";
+echo "Permissions sync complete.\n";
 
 // Rebuild the cache.
 echo "Clearing cache.\n";

--- a/web/private/scripts/drush_config_distro_update.php
+++ b/web/private/scripts/drush_config_distro_update.php
@@ -2,8 +2,11 @@
 
 // Ensure update mode is 'merge' and run config-distro-update.
 echo "Running Config Distro update...\n";
-passthru('drush -n -y state:set config_sync.update_mode 1 --input-format=integer');
-passthru('drush -n -y config-distro-update');
+passthru('drush -n -y config-distro-update --update-mode=1');
+echo "Config Distro update complete.\n";
+
+echo "Syncing permissions...\n";
+passthru('drush -n -y az-core-config-add-permissions');
 echo "Config Distro update complete.\n";
 
 // Rebuild the cache.


### PR DESCRIPTION
Config sync has new options for changing update-mode on the fly, which makes one of our steps simpler.
AZ Core has a new drush command for syncing permissions added upstream.