### PR TITLE
Closes #205: Update default PHP version to 8.2.

### DIFF
--- a/pantheon.upstream.yml
+++ b/pantheon.upstream.yml
@@ -4,7 +4,7 @@ web_docroot: true
 # values. Overriding this setting with either "full" or "full+subdomains" in
 # the site-specific pantheon.yml file is recommended prior to site go-live.
 enforce_https: transitional
-php_version: 8.1
+php_version: 8.2
 database:
   version: 10.4
 build_step: true


### PR DESCRIPTION
Targeting new `prepare-2.10.0` branch so we can merge any changes needed for Quickstart `2.10.x` into main all together after we 2.10.0 is available.