### PR TITLE
Closes #218 Create notify_cws.yml (GitHub-only fix, does not affect Pantheon sites)

### DIFF
--- a/.github/workflows/notify_cws.yml
+++ b/.github/workflows/notify_cws.yml
@@ -1,0 +1,17 @@
+name: Notify Campus Web Services
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  notify-cws:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.CWS_REPO_DISPATCH_TOKEN }}
+          repository: uaz-web/devops-tools
+          event-type: az_quickstart_release_available_on_pantheon


### PR DESCRIPTION
This workflow notifies the Campus Web Services team when there is a new Quickstart release.

Notice: This workflow requires a Personal Access Token be added to this repo as a Secret and it must be named CWS_REPO_DISPATCH_TOKEN 

Closes #218 