### PR TITLE
Closes #230: Update drupal/pantheon_advanced_page_cache requirement from 2.1.2 to 2.2.0

### DIFF
--- a/upstream/composer.json
+++ b/upstream/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "az-digital/az_quickstart": "2.9.5",
+        "az-digital/az_quickstart": "2.9.7",
         "composer/installers": "^2.0",
         "cweagans/composer-patches": "^1.7",
         "drupal/config_import_single": "2.0.0",

--- a/upstream/composer.json
+++ b/upstream/composer.json
@@ -16,7 +16,7 @@
         "drupal/config_import_single": "2.0.0",
         "drupal/core-composer-scaffold": "^10.2",
         "drupal/core-recommended": "^10.2",
-        "drupal/pantheon_advanced_page_cache": "2.1.2",
+        "drupal/pantheon_advanced_page_cache": "2.2.0",
         "drupal/redis": "1.7",
         "drush/drush": "^12.4.3",
         "oomphinc/composer-installers-extender": "^2.0.0",


### PR DESCRIPTION
https://www.drupal.org/project/pantheon_advanced_page_cache/releases/2.2.0