### PR TITLE
Closes #243: Add additional config to upstream/composer.json to fix dependabot.

### DIFF
--- a/upstream/composer.json
+++ b/upstream/composer.json
@@ -6,6 +6,10 @@
         {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
+        },
+        {
+            "type": "composer",
+            "url": "https://asset-packagist.org"
         }
     ],
     "require": {
@@ -25,5 +29,7 @@
     },
     "extra": {
         "enable-patching": true
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }


### PR DESCRIPTION
These changes should alllow `upstream/composer.json` to be updated on its own by composer/dependabot.

Running this command within the `upstream` directory seems to work locally with these changes applied (didn't work without these changes):

```
composer update -W --dry-run
```