### PR TITLE
Close #357 Add 'smart_title_ui' to list of modules to ignore when using config staging workflow.

### DIFF
--- a/web/sites/default/settings.upstream.php
+++ b/web/sites/default/settings.upstream.php
@@ -66,7 +66,7 @@ $config['system.performance']['fast_404']['enabled'] = TRUE;
 /**
  * Exclude dev modules + associated config from config exports/imports.
  */
-$settings['config_exclude_modules'] = ['devel', 'field_ui', 'views_ui'];
+$settings['config_exclude_modules'] = ['devel', 'field_ui', 'views_ui' , 'smart_title_ui'];
 
 /**
  * Default configuration for all Pantheon Environment requests.


### PR DESCRIPTION
I've recently run into an issue where smart title ui module is enabled on my live site when I did not want it to be.