### PR TITLE
Closes #379: Update Notify CWS action for Quickstart 3.x

### DIFF
--- a/.github/workflows/notify_cws.yml
+++ b/.github/workflows/notify_cws.yml
@@ -3,7 +3,7 @@ name: Notify Campus Web Services
 on:
   push:
     branches:
-      - master
+      - 3.x
 
 jobs:
   notify-cws:


### PR DESCRIPTION
Updates the "Notify Campus Web Services" action to be triggered on pushes to the `3.x` branch instead of the `master` branch.

This action dispatches an `az_quickstart_release_available_on_pantheon event` to `uaz-web/devops-tools`, which triggers the [Update Starter Site](https://github.com/uaz-web/devops-tools/blob/main/.github/workflows/update-starter-site.yml) workflow in that repo. We would like the starter site to be on Quickstart 3.x going forward.

#### Questions

1. I believe this change should be made to the `master` branch. Do we need to make it to the `3.x` branch as well?