### PR TITLE
Update Arizona Quickstart to 3.2.0

### DIFF
--- a/upstream/composer.json
+++ b/upstream/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=8.3",
-        "az-digital/az_quickstart": "3.2.0-beta2",
+        "az-digital/az_quickstart": "3.2.0",
         "composer/installers": "^2.3",
         "cweagans/composer-patches": "^1.7",
         "drupal/config_import_single": "2.0.2",

--- a/upstream/composer.json
+++ b/upstream/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=8.3",
-        "az-digital/az_quickstart": "3.1.2",
+        "az-digital/az_quickstart": "3.2.0-alpha1",
         "composer/installers": "^2.3",
         "cweagans/composer-patches": "^1.7",
         "drupal/config_import_single": "2.0.2",

--- a/upstream/composer.json
+++ b/upstream/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=8.3",
-        "az-digital/az_quickstart": "3.2.0-alpha1",
+        "az-digital/az_quickstart": "3.2.0-alpha2",
         "composer/installers": "^2.3",
         "cweagans/composer-patches": "^1.7",
         "drupal/config_import_single": "2.0.2",

--- a/upstream/composer.json
+++ b/upstream/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=8.3",
-        "az-digital/az_quickstart": "3.2.0-beta1",
+        "az-digital/az_quickstart": "3.2.0-beta2",
         "composer/installers": "^2.3",
         "cweagans/composer-patches": "^1.7",
         "drupal/config_import_single": "2.0.2",

--- a/upstream/composer.json
+++ b/upstream/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=8.3",
-        "az-digital/az_quickstart": "3.2.0-alpha2",
+        "az-digital/az_quickstart": "3.2.0-beta1",
         "composer/installers": "^2.3",
         "cweagans/composer-patches": "^1.7",
         "drupal/config_import_single": "2.0.2",


### PR DESCRIPTION
Release notes: https://github.com/az-digital/az_quickstart/releases/tag/3.2.0