### PR TITLE
az-digital/az_quickstart#5381, #367: Add pantheon_secets to LTS (backport of #368)

### DIFF
--- a/upstream/composer.json
+++ b/upstream/composer.json
@@ -21,6 +21,7 @@
         "drupal/core-composer-scaffold": "~10.5.0",
         "drupal/core-recommended": "~10.5.0",
         "drupal/pantheon_advanced_page_cache": "2.3.4",
+        "drupal/pantheon_secrets": "1.0.6",
         "drupal/redis": "1.11.0",
         "drush/drush": "^12.4.3 || ^13.4.0",
         "oomphinc/composer-installers-extender": "^2.0.0",


### PR DESCRIPTION
LTS backport of #368 for #367.

This is needed for az-digital/az_quickstart#5381 (and az-digital/az_quickstart#5383)