### PR TITLE
Update Arizona Quickstart to 2.14.6 (includes additional changes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,22 @@ Optionally add new permissions from the upstream onto the az_quickstart managed 
 terminus drush <sitename>.live -- az-core-config-add-permissions -y
 ```
 
+## Upgrading to Quickstart 3
+It is probably best to verify that your site works on the new upstream before updating your master environments. Otherwise, you could end up in a precarious position blocking the Dev → Test → Live deployment runway.
+
+One approach is to create a new Multidev environment and test the upstream update there. You can then pull that environment locally and apply the upstream changes like this:
+`git pull -Xtheirs https://github.com/az-digital/az-quickstart-pantheon.git 3.x --ff`
+The Quickstart 3 upstream is a new, separate upstream from Quickstart 2; you must switch your site's upstream in order to update to Quickstart 3.
+
+### Before you begin
+Ensure your site is on the latest 2.14.x release, with all database updates and distribution updates applied or merged prior to upgrading to prevent errors.
+
+### Instructions
+1. Run `terminus upstream:list` to find the ID for the Quickstart 3 upstream.
+2. Run `terminus site:upstream:set` and select the Quickstart 3 upstream.
+3. Apply any pending database and config distro updates.
+
+
 ## Determining whether the Quickstart 1 to Quickstart 2 migration path is viable for your site.
 
 When tasked with migrating a Quickstart 1 site to a Quickstart 2 site these are the steps:

--- a/upstream/composer.json
+++ b/upstream/composer.json
@@ -21,6 +21,7 @@
         "drupal/core-composer-scaffold": "~10.5.0",
         "drupal/core-recommended": "~10.5.0",
         "drupal/pantheon_advanced_page_cache": "2.3.4",
+        "drupal/pantheon_secrets": "1.0.6",
         "drupal/redis": "1.11.0",
         "drush/drush": "^12.4.3 || ^13.4.0",
         "oomphinc/composer-installers-extender": "^2.0.0",

--- a/upstream/composer.json
+++ b/upstream/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "az-digital/az_quickstart": "2.14.5",
+        "az-digital/az_quickstart": "2.14.6",
         "composer/installers": "^2.0",
         "cweagans/composer-patches": "^1.7",
         "drupal/config_import_single": "2.0.2",


### PR DESCRIPTION
https://github.com/az-digital/az_quickstart/releases/tag/2.14.6

## Changes in this PR
 - Update the Quickstart 2 LTS upstream to 2.14.6
 - Add the pantheon_secrets module
 - Update the README with information about upgrading to Quickstart 3