### PR TITLE
CWS-5991: Use generated token for GitHub devops-tools notification workflow (does not affect sites on Pantheon).

### DIFF
--- a/.github/workflows/notify_cws.yml
+++ b/.github/workflows/notify_cws.yml
@@ -9,9 +9,18 @@ jobs:
   notify-cws:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate repository dispatch token
+        id: generate-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ vars.CWS_REPO_DISPATCH_CLIENT_ID }}
+          private-key: ${{ secrets.CWS_REPO_DISPATCH_PRIVATE_KEY }}
+          repositories: |
+            devops-tools
+
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.CWS_REPO_DISPATCH_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
           repository: uaz-web/devops-tools
           event-type: az_quickstart_release_available_on_pantheon

--- a/.github/workflows/notify_cws.yml
+++ b/.github/workflows/notify_cws.yml
@@ -1,6 +1,7 @@
 name: Notify Campus Web Services
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - 3.x


### PR DESCRIPTION
Reopens https://github.com/az-digital/az-quickstart-pantheon/pull/419

[CWS-5991](https://uarizona.atlassian.net/browse/CWS-5991)

[CWS-5991]: https://uarizona.atlassian.net/browse/CWS-5991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


See https://github.com/actions/create-github-app-token