### PR TITLE
Update Arizona Quickstart to 3.3.6 (includes core security update for SA-CORE-2026-004).

### DIFF
--- a/upstream/composer.json
+++ b/upstream/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=8.3",
-        "az-digital/az_quickstart": "3.3.5",
+        "az-digital/az_quickstart": "3.3.6",
         "composer/installers": "^2.3",
         "cweagans/composer-patches": "^1.7",
         "drupal/config_import_single": "2.0.2",


### PR DESCRIPTION
https://github.com/az-digital/az_quickstart/releases/tag/3.3.6