### PR TITLE
Workaround for vulnerabilities in symfony/polyfill-intl-idn and twig

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,9 @@
         }
     ],
     "require": {
-        "internal/upstream-configuration": "*"
+        "internal/upstream-configuration": "*",
+        "symfony/polyfill-intl-idn":"1.38.1 as 1.37.0",
+        "twig/twig": "3.27.0 as 3.26.0"
     },
     "conflict": {
         "drupal/drupal": "*"


### PR DESCRIPTION
Temporary workaround for insecure drupal core dependencies https://www.drupal.org/project/drupal/issues/3592065 https://symfony.com/blog/cve-2026-46644-insecure-equivalence-in-symfony-polyfill-intl-idn-for-ascii-only-xn-labels https://symfony.com/blog/twig-3-27-0-released