### PR TITLE
Update Arizona Quickstart to 3.4.1 (includes core security updates for SA-CORE-2026-005 to -009).

### DIFF
--- a/upstream/composer.json
+++ b/upstream/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=8.3",
-        "az-digital/az_quickstart": "3.4.0",
+        "az-digital/az_quickstart": "3.4.1",
         "composer/installers": "^2.3",
         "cweagans/composer-patches": "^1.7",
         "drupal/config_import_single": "2.0.2",


### PR DESCRIPTION
https://github.com/az-digital/az_quickstart/releases/tag/3.4.1