### PR TITLE
Update Arizona Quickstart to 3.4.3 (includes paragraphs security updates for SA-CONTRIB-2026-060 to -061).

### DIFF
--- a/upstream/composer.json
+++ b/upstream/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=8.3",
-        "az-digital/az_quickstart": "3.4.2",
+        "az-digital/az_quickstart": "3.4.3",
         "composer/installers": "^2.3",
         "cweagans/composer-patches": "^1.7",
         "drupal/config_import_single": "2.0.2",


### PR DESCRIPTION
Release notes: https://github.com/az-digital/az_quickstart/releases/tag/3.4.3