### PR TITLE
Update Arizona Quickstart to 3.4.5 (includes core security updates for SA-CORE-2026-010 to -012).

### DIFF
--- a/.github/workflows/notify_cws.yml
+++ b/.github/workflows/notify_cws.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           client-id: ${{ vars.CWS_REPO_DISPATCH_CLIENT_ID }}
           private-key: ${{ secrets.CWS_REPO_DISPATCH_PRIVATE_KEY }}
+          owner: uaz-web
           repositories: |
             devops-tools
 

--- a/upstream/composer.json
+++ b/upstream/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=8.3",
-        "az-digital/az_quickstart": "3.4.4",
+        "az-digital/az_quickstart": "3.4.5",
         "composer/installers": "^2.3",
         "cweagans/composer-patches": "^1.7",
         "drupal/config_import_single": "2.0.2",


### PR DESCRIPTION
## Changes

- Update Quickstart to [3.4.5](https://github.com/az-digital/az_quickstart/releases/tag/3.4.5)
- From @hayitsbacon: Add owner field to Notify CWS workflow (to fix failing workflows for updating starter and sandbox sites)